### PR TITLE
using Adafruit_DHT instead of adafruit-circuitpython-dht

### DIFF
--- a/custom_components/dht/manifest.json
+++ b/custom_components/dht/manifest.json
@@ -3,8 +3,7 @@
   "name": "DHT Sensor",
   "documentation": "https://www.home-assistant.io/integrations/dht",
   "requirements": [
-    "adafruit-circuitpython-dht==3.7.2",
-    "RPi.GPIO==0.7.1"
+    "Adafruit_DHT"
   ],
   "codeowners": [
     "@Ligio"


### PR DESCRIPTION
adafruit-circuitpython-dht can't be installed in latest HAOS because of missing dependencies that were removed.
Adafruit_DHT is working fine instead.